### PR TITLE
executable variable is not defined in extractors/executables

### DIFF
--- a/baseline/extractors/executables.py
+++ b/baseline/extractors/executables.py
@@ -60,6 +60,8 @@ class PortableExecutable(models.Extractor):
         self.kind = kind
         self.remap = remap
 
+        self.executable = None
+
         try:
             self.executable: pefile.PE = pefile.PE(self.entry, fast_load=True)
 
@@ -77,7 +79,8 @@ class PortableExecutable(models.Extractor):
             ) from exception
 
     def __del__(self: object) -> None:
-        self.executable.close()
+        if self.executable:
+            self.executable.close()
 
     def run(self: object, record: schema.Record) -> None:
         setattr(


### PR DESCRIPTION
`self.executable` is not defined in `baseline/extractors/executables.py `, so  in the `__del__` method, it crashes.

```
$ baseline new /etc      
Exception ignored in: <function PortableExecutable.__del__ at 0x7fd1142c98b0>
Traceback (most recent call last):
  File "/home/git/baseline/env/lib/python3.9/site-packages/baseline/extractors/executables.py", line 80, in __del__
    if self.executable:
AttributeError: 'PortableExecutable' object has no attribute 'executable'
All done! 💪

Entries Processed : 1592
Output Format     : ndjson
Output File       : /home/git/baseline/20211106191044.heaven.ndjson.xz
Size              : 1.2 MB
Total Time        : 0:00:01.993753
```